### PR TITLE
revised model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,16 @@ package: release/windows.zip release/darwin.zip release/linux.tgz
 release/linux.tgz: release/linux/skupper
 	tar -czf release/linux.tgz -C release/linux/ skupper
 
-release/linux/skupper: cmd/skupper.go
+release/linux/skupper: cmd/skupper/skupper.go
 	GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=${VERSION}" -o release/linux/skupper cmd/skupper/skupper.go
 
-release/windows/skupper: cmd/skupper.go
+release/windows/skupper: cmd/skupper/skupper.go
 	GOOS=windows GOARCH=amd64 go build -ldflags="-X main.version=${VERSION}" -o release/windows/skupper cmd/skupper/skupper.go
 
 release/windows.zip: release/windows/skupper
 	zip -j release/windows.zip release/windows/skupper
 
-release/darwin/skupper: cmd/skupper.go
+release/darwin/skupper: cmd/skupper/skupper.go
 	GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=${VERSION}" -o release/darwin/skupper cmd/skupper/skupper.go
 
 release/darwin.zip: release/darwin/skupper

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -640,13 +640,13 @@ func ensureProxyController(enableServiceSync bool, router *appsv1.Deployment, ku
 		if os.Getenv("SKUPPER_CONTROLLER_IMAGE") != "" {
 			image = os.Getenv("SKUPPER_CONTROLLER_IMAGE")
 		} else {
-			image = "quay.io/gordons/skupper-controller"
+			image = "quay.io/skupper/controller:preview2"
 		}
 		var proxyImage string
 		if os.Getenv("SKUPPER_PROXY_IMAGE") != "" {
 			proxyImage = os.Getenv("SKUPPER_PROXY_IMAGE")
 		} else {
-			proxyImage = "quay.io/gordons/skupper-proxy"
+			proxyImage = "quay.io/skupper/proxy:preview2"
 		}
 		container := corev1.Container{
 			Image: image,

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -1889,7 +1889,7 @@ func stringifySelector(labels map[string]string) string {
 	result := ""
 	for k, v := range labels {
 		if result != "" {
-			result += "&"
+			result += ","
 		}
 		result += k
 		result += "="

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -640,13 +640,13 @@ func ensureProxyController(enableServiceSync bool, router *appsv1.Deployment, ku
 		if os.Getenv("SKUPPER_CONTROLLER_IMAGE") != "" {
 			image = os.Getenv("SKUPPER_CONTROLLER_IMAGE")
 		} else {
-			image = "quay.io/skupper/controller:preview2"
+			image = "quay.io/skupper/controller"
 		}
 		var proxyImage string
 		if os.Getenv("SKUPPER_PROXY_IMAGE") != "" {
 			proxyImage = os.Getenv("SKUPPER_PROXY_IMAGE")
 		} else {
-			proxyImage = "quay.io/skupper/proxy:preview2"
+			proxyImage = "quay.io/skupper/proxy"
 		}
 		container := corev1.Container{
 			Image: image,

--- a/pkg/kube/pods.go
+++ b/pkg/kube/pods.go
@@ -65,7 +65,12 @@ func GetReadyPod(namespace string, clientset *kubernetes.Clientset, component st
 func GetImageVersion(pod *corev1.Pod, container string) string {
 	for _, c := range pod.Status.ContainerStatuses {
 		if c.Name == container {
-			return fmt.Sprintf("%s (%s)", c.Image, strings.Split(c.ImageID, "@")[1][:19])
+			parts := strings.Split(c.ImageID, "@")
+			if len(parts) > 1 && len(parts[1]) >= 19 {
+				return fmt.Sprintf("%s (%s)", c.Image, parts[1][:19])
+			} else {
+				return fmt.Sprintf("%s", c.Image)
+			}
 		}
 	}
 	return "not-found"


### PR DESCRIPTION
Use service definitions stored in configmap.
Add expose/unexpose commands as alternative approach to defining services.
Still support existing annotation, but also support annotation on deployment.