### PR TITLE
smoke-test pipeline fix: sleep before and after port forwarding.

### DIFF
--- a/pkg/smoke/tcp_echo/tcp_echo.go
+++ b/pkg/smoke/tcp_echo/tcp_echo.go
@@ -108,13 +108,13 @@ func (r *SmokeTestRunner) RunTests() {
 	fmt.Printf("Public service ClusterIp = %q\n", publicService.Spec.ClusterIP)
 	fmt.Printf("Private service ClusterIp = %q\n", privateService.Spec.ClusterIP)
 
+	time.Sleep(20 * time.Second)
+
 	r.Pub1Cluster.KubectlExecAsync("port-forward service/tcp-go-echo 9090:9090")
 	r.Priv1Cluster.KubectlExecAsync("port-forward service/tcp-go-echo 9091:9090")
 
-	time.Sleep(2 * time.Second) //give time to port forwarding to start
+	time.Sleep(20 * time.Second) //give time to port forwarding to start
 
-	//sendReceive(publicService.Spec.ClusterIP + ":9090")
-	//sendReceive(privateService.Spec.ClusterIP + ":9090")
 	sendReceive("127.0.0.1:9090")
 	sendReceive("127.0.0.1:9091")
 }


### PR DESCRIPTION
Sleep before is needed since it seems that although the service is ready it is needed a couple more seconds for the port forwarding command not crashing due to the target port does not exist yet.

Sleep after is needed to give time to the port-forwarding background process to start working.

Without any of these sleeps the job fails with a connection refused when trying to send the test message.

```2020/04/11 14:57:36 Dial failed: dial tcp 127.0.0.1:9090: connect: connection refused```
