### PR TITLE
configuring slow jobs to run after fast jobs, and ONLY if fast jobs succeed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,24 @@ yaml-templates:
       root: .
       paths:
         - dist
+
+  requires_fast_jobs: &requires_fast_jobs
+    requires:
+      - build-linux-386
+      - build-linux-amd64
+      - build-darwin-386
+      - build-darwin-amd64
+      - build-windows-386
+      - build-windows-amd64
+      - build-linux-arm
+      - build-linux-arm64
+      - test
+
+  requires_slow_jobs: &requires_slow_jobs
+    requires:
+      - minikube_local_cluster_e2e_tests
+      - kind_local_cluster_e2e_tests
+
 workflows:
   version: 2.1
   build-workflow:
@@ -151,24 +169,17 @@ workflows:
           <<: *branch_filters
           pre-steps:
             - prepare_for_local_cluster_e2e
+          <<: *requires_fast_jobs
 
       - kind_local_cluster_e2e_tests:
           <<: *branch_filters
           pre-steps:
             - prepare_for_local_cluster_e2e
+          <<: *requires_fast_jobs
 
       - publish-github-release:
           <<: *release_filters
-          requires:
-            - build-linux-386
-            - build-linux-amd64
-            - build-darwin-386
-            - build-darwin-amd64
-            - build-windows-386
-            - build-windows-amd64
-            - build-linux-arm
-            - build-linux-arm64
-            - test
+          <<: *requires_slow_jobs
 
 jobs:
   build-linux-amd64: &go_build


### PR DESCRIPTION
If fast test fails, pipeline is aborted and we do not waste time waiting for slow tests.

pipeline workflow before:
![image](https://user-images.githubusercontent.com/13121406/80132288-ce782380-8571-11ea-8d4e-0addfb2c778e.png)

pipeline workflow now:
![image](https://user-images.githubusercontent.com/13121406/80132188-aee0fb00-8571-11ea-8c50-f2804b9b0a7b.png)
